### PR TITLE
Refactor: profile and region only in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Usage example:
 use BEdita\I18n\Aws\Core\Translator;
 
 $translator = new Translator();
-$translator->setup(['auth_key' => 'your-auth-key', 'profile' => 'your-profile', 'region' => 'your-region']);
+$translator->setup([
+    'profile' => 'your-profile', // the AWS profile
+    'region' => 'your-region', // the AWS region
+]);
 $translation = $translator->translate(['Hello world!'], 'en', 'it');
 ```

--- a/src/Core/Translator.php
+++ b/src/Core/Translator.php
@@ -37,7 +37,7 @@ class Translator implements TranslatorInterface
      *
      * @var array
      */
-    protected array $options = [];
+    protected array $options = ['version' => 'latest'];
 
     /**
      * Setup translator engine.
@@ -47,13 +47,8 @@ class Translator implements TranslatorInterface
      */
     public function setup(array $options = []): void
     {
-        $this->options = $options;
-        $this->options['key'] = (string)Hash::get($options, 'auth_key');
-        $this->awsClient = new TranslateClient([
-            'profile' => $this->options['profile'],
-            'region' => $this->options['region'],
-            'version' => 'latest',
-        ]);
+        $this->options = array_merge($options, $this->options);
+        $this->awsClient = new TranslateClient($this->options);
     }
 
     /**

--- a/src/Core/Translator.php
+++ b/src/Core/Translator.php
@@ -17,7 +17,6 @@ namespace BEdita\I18n\Aws\Core;
 use Aws\Translate\TranslateClient;
 use BEdita\I18n\Core\TranslatorInterface;
 use Cake\Log\LogTrait;
-use Cake\Utility\Hash;
 use Exception;
 use Psr\Log\LogLevel;
 

--- a/tests/TestCase/Core/TranslatorTest.php
+++ b/tests/TestCase/Core/TranslatorTest.php
@@ -17,6 +17,7 @@ namespace BEdita\I18n\Aws\Test\Core;
 use Aws\Translate\TranslateClient;
 use BEdita\I18n\Aws\Core\Translator;
 use Cake\TestSuite\TestCase;
+use ReflectionClass;
 
 /**
  * {@see \BEdita\I18n\AWS\Core\Translator} Test Case
@@ -39,8 +40,18 @@ class TranslatorTest extends TestCase
                 return $this->awsClient;
             }
         };
-        $translator->setup(['auth_key' => 'test-auth-key', 'profile' => 'test-profile', 'region' => 'test-region']);
+        $translator->setup(['profile' => 'test-profile', 'region' => 'test-region']);
         static::assertNotEmpty($translator->getAwsClient());
+        $expected = [
+            'profile' => 'test-profile',
+            'region' => 'test-region',
+            'version' => 'latest',
+        ];
+        $reflection = new ReflectionClass($translator);
+        $property = $reflection->getProperty('options');
+        $property->setAccessible(true);
+        $actual = $property->getValue($translator);
+        static::assertSame($expected, $actual);
     }
 
     /**
@@ -58,7 +69,7 @@ class TranslatorTest extends TestCase
                 return $this->awsClient;
             }
         };
-        $translator->setup(['auth_key' => 'test-auth-key', 'profile' => 'test-profile', 'region' => 'test-region']);
+        $translator->setup(['profile' => 'test-profile', 'region' => 'test-region']);
         $result = $translator->translate(['test'], 'en', 'it');
         static::assertEquals('{"translation":[]}', $result);
     }

--- a/tests/TestCase/Core/TranslatorTest.php
+++ b/tests/TestCase/Core/TranslatorTest.php
@@ -41,7 +41,6 @@ class TranslatorTest extends TestCase
             }
         };
         $translator->setup(['profile' => 'test-profile', 'region' => 'test-region']);
-        static::assertNotEmpty($translator->getAwsClient());
         $expected = [
             'profile' => 'test-profile',
             'region' => 'test-region',
@@ -52,6 +51,7 @@ class TranslatorTest extends TestCase
         $property->setAccessible(true);
         $actual = $property->getValue($translator);
         static::assertSame($expected, $actual);
+        static::assertNotEmpty($translator->getAwsClient());
     }
 
     /**
@@ -69,7 +69,10 @@ class TranslatorTest extends TestCase
                 return $this->awsClient;
             }
         };
-        $translator->setup(['profile' => 'test-profile', 'region' => 'test-region']);
+        $translator->setup([
+            'profile' => 'test-profile',
+            'region' => 'test-region',
+        ]);
         $result = $translator->translate(['test'], 'en', 'it');
         static::assertEquals('{"translation":[]}', $result);
     }


### PR DESCRIPTION
This provides a refactor to use `profile` and `region` only in setup. `auth_key` was not used.