### PR TITLE
refactor: remove phpunit CoversMethod

### DIFF
--- a/tests/TestCase/Core/TranslatorTest.php
+++ b/tests/TestCase/Core/TranslatorTest.php
@@ -18,15 +18,12 @@ use Aws\Translate\TranslateClient;
 use BEdita\I18n\Aws\Core\Translator;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
 use ReflectionClass;
 
 /**
  * {@see \BEdita\I18n\AWS\Core\Translator} Test Case
  */
 #[CoversClass(Translator::class)]
-#[CoversMethod(Translator::class, 'setup')]
-#[CoversMethod(Translator::class, 'translate')]
 class TranslatorTest extends TestCase
 {
     /**


### PR DESCRIPTION
This removes phpunit `CoversMethod` from tests files.
It is not "repeatable", so it originated phpstan errors.
`CoversClass` is enough.